### PR TITLE
create new driver for kuman lcd full HD 3.5 inch touch display

### DIFF
--- a/demo/src/main/java/eu/vranckaert/driver/touch/demo/ThingsApplication.java
+++ b/demo/src/main/java/eu/vranckaert/driver/touch/demo/ThingsApplication.java
@@ -2,6 +2,7 @@ package eu.vranckaert.driver.touch.demo;
 
 import eu.vranckaert.driver.touch.TouchScreenDriverApplication;
 import eu.vranckaert.driver.touch.profile.DriverProfile;
+import eu.vranckaert.driver.touch.profile.KumanDriverProfile;
 import eu.vranckaert.driver.touch.profile.WaveshareProfile;
 
 /**
@@ -11,6 +12,6 @@ import eu.vranckaert.driver.touch.profile.WaveshareProfile;
 public class ThingsApplication extends TouchScreenDriverApplication {
     @Override
     public DriverProfile getDriverProfile() {
-        return WaveshareProfile.getInstance(WaveshareProfile.DIMENSION_800_480);
+        return KumanDriverProfile.getInstance(KumanDriverProfile.DIMENSION_1920_1080);
     }
 }

--- a/touch/src/main/java/eu/vranckaert/driver/touch/driver/KumanDriver.java
+++ b/touch/src/main/java/eu/vranckaert/driver/touch/driver/KumanDriver.java
@@ -1,0 +1,25 @@
+package eu.vranckaert.driver.touch.driver;
+
+import eu.vranckaert.driver.touch.profile.SPIDriverProfile;
+
+public class KumanDriver extends XPT2046Driver {
+
+    public KumanDriver(SPIDriverProfile driverProfile) {
+        super(driverProfile, true, true, true, true, true);
+    }
+
+    @Override
+    public boolean isPressing(byte[] buffer) {
+        return buffer[1] != 0;
+    }
+
+    @Override
+    public int getSpiChannel() {
+        return 1;
+    }
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+}

--- a/touch/src/main/java/eu/vranckaert/driver/touch/profile/KumanDriverProfile.java
+++ b/touch/src/main/java/eu/vranckaert/driver/touch/profile/KumanDriverProfile.java
@@ -1,0 +1,27 @@
+package eu.vranckaert.driver.touch.profile;
+
+import eu.vranckaert.driver.touch.driver.Driver;
+import eu.vranckaert.driver.touch.driver.KumanDriver;
+
+public class KumanDriverProfile extends SPIDriverProfile {
+
+    public static final ScreenDimension DIMENSION_1920_1080 = new ScreenDimension(1920, 1080, ScreenDimension.Ratio.R_16_10);
+
+    private static KumanDriverProfile INSTANCE;
+
+    private KumanDriverProfile(ScreenDimension screenDimension) {
+        super(Vendor.KUMAN, screenDimension);
+    }
+
+    public static KumanDriverProfile getInstance(ScreenDimension screenDimension) {
+        if(INSTANCE == null) {
+            INSTANCE = new KumanDriverProfile(screenDimension);
+        }
+        return INSTANCE;
+    }
+
+    @Override
+    public Driver getDriver() {
+        return new KumanDriver(this);
+    }
+}

--- a/touch/src/main/java/eu/vranckaert/driver/touch/profile/Vendor.java
+++ b/touch/src/main/java/eu/vranckaert/driver/touch/profile/Vendor.java
@@ -3,5 +3,6 @@ package eu.vranckaert.driver.touch.profile;
 public enum Vendor {
     KEDEI,
     WAVESHARE,
-    UNKNOWN;
+    KUMAN,
+    UNKNOWN
 }


### PR DESCRIPTION
I've created a new driver for the kuman 3.5 inch touch display.

Can check screen here http://www.kumantech.com/kuman-35-inch-resolution-adjustable-full-hd-tft-lcd-display-monitor-with-protective-case-sc6ac_p0417.html

I've tested the driver with the demo app. All seems to work fine. The only one thing that I saw is that the cursor doesn't automatically move to the touch position. I have to bring it to the target by sliding before. Don't know if it's normal.
If anything is wrong please let me know.

Hope it will be compliant.
Good job ! You did the most important part. It's so easy to create new driver.